### PR TITLE
Initial commit for http load tester

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use the official Python image
+FROM python:3.11-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed packages
+RUN pip install --no-cache-dir aiohttp pytest pytest-aiohttp
+
+# Set the default command to run when the container starts
+ENTRYPOINT ["python", "load_tester.py"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+# Released under MIT License
+
+Copyright (c) 2013 Mark Otto.
+
+Copyright (c) 2017 Andrew Fong.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
-# http-load-testing
+# HTTP Load-Testing Tool
+
+This tool allows you to perform load testing on HTTP endpoints. You can specify the queries per second (QPS) and the duration for the test, and it reports latencies and error rates.
+
+## Features
+
+- Generates HTTP requests at a specified QPS.
+- Measures response latencies and reports errors.
+- Asynchronous design for handling multiple requests concurrently.
+- Dockerized for easy setup and usage.
+
+## Requirements
+
+- [Docker](https://www.docker.com/) installed on your system.
+
+## Getting Started
+
+### 1. Clone the Repository
+
+Clone the repository to your local machine.
+
+```bash
+git clone https://github.com/yourusername/http-load-testing.git
+cd http-load-testing
+```
+
+### 2. Build the Docker Image
+Use the Dockerfile to build the Docker image.
+
+```bash
+docker build -t http-load-tester .
+```
+
+### 3. Run the Docker Container
+Run the container, specifying the URL, QPS, and duration. Replace `http://example.com` with your target URL.
+
+```bash
+docker run --rm http-load-tester http://example.com --qps 5 --duration 30
+```
+Command-Line Arguments
+- ``URL``: The URL to test.
+- ``--qps``: Queries per second (default: 1).
+- ``--duration``: Duration of the test in seconds (default: 10).
+
+### 4. Example Usage
+Test Google's Homepage at 5 QPS for 30 Seconds
+```bash
+docker run --rm http-load-tester http://www.google.com --qps 5 --duration 30
+```
+
+Output
+The output will include average latency, latency standard deviation, total requests, and errors.
+
+```
+Average Latency: 0.23s
+Latency Standard Deviation: 0.05s
+Total Requests: 150
+Errors: 0
+```
+
+
+## Development and Debugging
+Access the Docker Container
+You can run a bash shell inside the container for debugging:
+
+```bash
+docker run -it --entrypoint /bin/bash http-load-tester
+```
+Manual Run Inside Container
+After accessing the container, you can run the script manually for testing:
+
+```bash
+python load_tester.py http://www.example.com --qps 5 --duration 30
+```
+
+## Files
+- ``load_tester.py``: The main Python script for load testing.
+- ``Dockerfile``: Dockerfile to build the Docker image.
+- ``README.md``: This README file.
+
+
+## Notes
+- Ensure your target URL is accessible and returns a valid response.
+- The tool uses ``aiohttp`` for asynchronous HTTP requests.
+- This tool is for testing and educational purposes only. Use responsibly.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/load_tester.py
+++ b/load_tester.py
@@ -1,0 +1,73 @@
+import asyncio
+import aiohttp
+import time
+import argparse
+from statistics import mean, stdev
+
+async def fetch(session, url):
+    """
+    Asynchronously fetches a URL and records latency.
+    """
+    try:
+        async with session.get(url) as response:
+            latency = response.headers.get('X-Response-Time', 0)
+            return latency, response.status
+    except Exception as e:
+        return 0, 500
+
+async def worker(queue, session, stats):
+    """
+    A coroutine that gets URLs from a queue and processes them.
+    """
+    while True:
+        url = await queue.get()
+        if url is None:
+            break
+
+        start_time = time.time()
+        latency, status = await fetch(session, url)
+        end_time = time.time()
+
+        duration = end_time - start_time
+        stats.append((duration, status))
+
+        queue.task_done()
+
+async def main(url, qps, duration):
+    queue = asyncio.Queue()
+    stats = []
+
+    async with aiohttp.ClientSession() as session:
+        workers = [asyncio.create_task(worker(queue, session, stats)) for _ in range(qps)]
+
+        end_time = time.time() + duration
+        while time.time() < end_time:
+            await queue.put(url)
+            await asyncio.sleep(1 / qps)
+
+        for _ in range(qps):
+            await queue.put(None)
+
+        await asyncio.gather(*workers)
+
+    latencies = [stat[0] for stat in stats if stat[1] == 200]
+    error_count = sum(1 for stat in stats if stat[1] != 200)
+
+    if latencies:
+        print(f"Average Latency: {mean(latencies):.2f}s")
+        print(f"Latency Standard Deviation: {stdev(latencies):.2f}s")
+    else:
+        print("No successful requests.")
+
+    print(f"Total Requests: {len(stats)}")
+    print(f"Errors: {error_count}")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="HTTP Load-Testing Tool")
+    parser.add_argument('url', type=str, help='URL to test. eg: http://example.com')
+    parser.add_argument('--qps', type=int, default=1, help='Queries per second')
+    parser.add_argument('--duration', type=int, default=10, help='Duration of the test in seconds')
+
+    args = parser.parse_args()
+
+    asyncio.run(main(args.url, args.qps, args.duration))

--- a/test_load_test.py
+++ b/test_load_test.py
@@ -1,0 +1,66 @@
+import pytest
+import asyncio
+import aiohttp
+from aiohttp import web
+from unittest.mock import patch
+from load_tester import main
+
+@pytest.fixture
+async def mock_server():
+    # Setup a mock HTTP server with success and error routes
+    app = web.Application()
+    app.router.add_get('/success', lambda request: web.Response(text='Success', status=200))
+    app.router.add_get('/error', lambda request: web.Response(text='Error', status=500))
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    server = web.TCPSite(runner, 'localhost', 0)  # 0 for dynamic port assignment
+    await server.start()
+    
+    # Get the server's address
+    host = server._host
+    port = server._port
+
+    url = f'http://{host}:{port}'
+    
+    yield url
+
+    await server.stop()
+    await runner.cleanup()
+
+
+@pytest.mark.asyncio
+@patch('builtins.print')
+async def test_load_tester_success(mock_print, mock_server):
+    # Use the mock server's URL
+    url = f'{mock_server}/success'
+    await main(url, qps=5, duration=2)
+    
+    output = [call.args[0] for call in mock_print.call_args_list]
+    print(output)
+    assert any("Average Latency:" in line for line in output)
+    assert any("Total Requests:" in line for line in output)
+    assert any("Errors: 0" in line for line in output)
+
+
+@pytest.mark.asyncio
+@patch('builtins.print')
+async def test_load_tester_error(mock_print, mock_server):
+    # Use the mock server's URL
+    url = f'{mock_server}/error'
+    await main(url, qps=5, duration=2)
+    
+    output = [call.args[0] for call in mock_print.call_args_list]
+
+    assert any("Total Requests:" in line for line in output)
+    assert any("Errors:" in line for line in output)
+
+
+@pytest.mark.asyncio
+@patch('builtins.print')
+async def test_load_tester_invalid_url(mock_print):
+    await main('http://invalid_url', qps=1, duration=1)
+    
+    output = [call.args[0] for call in mock_print.call_args_list]
+
+    assert any("No successful requests." in line for line in output)


### PR DESCRIPTION
Initial commit for http load tester
- Add `load_tester` file and `test_load_tester` file
- What works now:
    - Takes an HTTP address as input
    - Support a --qps flag to generate requests at a given fixed QPS
    - Reports latencies and error rates
    - Build a runnable Docker container
- Add the user guide into the `README.md` file